### PR TITLE
Fix X-Accel-Buffering syntax.

### DIFF
--- a/src/SSE.php
+++ b/src/SSE.php
@@ -266,7 +266,7 @@ class SSE implements ArrayAccess
         $response = new StreamedResponse($callback, Response::HTTP_OK, array(
             'Content-Type' => 'text/event-stream',
             'Cache-Control' => 'no-cache',
-            'X-Accel-Buffering' => 'off' // Disables FastCGI Buffering on Nginx
+            'X-Accel-Buffering' => 'no' // Disables FastCGI Buffering on Nginx
         ));
 
         if($this->allow_cors){


### PR DESCRIPTION
X-Accel-Buffering header must be set to "no" instead of "off", otherwise nginx does't disable output buffering.